### PR TITLE
Support for configuring the time until the persistence cookie expires.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ class ApplicationController < ActionController::Base
 end
 ```
 
+By default, the cookie related to the MfaSession expires in 24 hours, but this can be changed:
+```ruby
+config/initializers/google_authenticator_rails.rb
+
+GoogleAuthenticatorRails.time_until_expiration = 1.month
+```
+
+
 ## Contributing
 
 1. Fork it

--- a/lib/google-authenticator-rails.rb
+++ b/lib/google-authenticator-rails.rb
@@ -25,7 +25,10 @@ GOOGLE_AUTHENTICATOR_RAILS_PATH = File.dirname(__FILE__) + "/google-authenticato
 module GoogleAuthenticatorRails
   # Drift is set to 6 because ROTP drift is not inclusive.  This allows a drift of 5 seconds.
   DRIFT = 6
-   
+
+  # How long a Session::Persistence cookie should last.
+  @@time_until_expiration = 24.hours
+
   def self.generate_password(secret, iteration)
     ROTP::HOTP.new(secret).at(iteration)
   end
@@ -40,5 +43,13 @@ module GoogleAuthenticatorRails
 
   def self.generate_secret
     ROTP::Base32.random_base32
+  end
+
+  def self.time_until_expiration
+    @@time_until_expiration
+  end
+
+  def self.time_until_expiration=(time_until_expiration)
+    @@time_until_expiration = time_until_expiration
   end
 end

--- a/lib/google-authenticator-rails/session/persistence.rb
+++ b/lib/google-authenticator-rails/session/persistence.rb
@@ -57,7 +57,7 @@ module GoogleAuthenticatorRails
         value = [token, user_id].join('::')
         {
           :value    => value,
-          :expires  => 24.hours.from_now
+          :expires  => GoogleAuthenticatorRails.time_until_expiration.from_now
         }
       end
 


### PR DESCRIPTION
Rather than being hardcoded to `24.hours`, the time until the persistence cookie expires is now defined by `GoogleAuthenticatorRails.time_until_expiration`.

With this change, the time can now be overridden in the Rails application by simply doing the following in an initializer:

``` ruby
# config/initializers/google_authenticator_rails.rb
GoogleAuthenticatorRails.time_until_expiration = 1.month
```
