### PR TITLE
Updates gemspec to preserve compatibility with activerecord 2.3.x

### DIFF
--- a/google-authenticator.gemspec
+++ b/google-authenticator.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Google::Authenticator::Rails::VERSION
   
   gem.add_dependency "rotp", "= 1.4.1"
-  gem.add_dependency "activerecord", "~> 3.2.16"
+  gem.add_dependency "activerecord", "< 4.0.0"
   gem.add_dependency "google-qr"
   gem.add_dependency "actionpack"
   


### PR DESCRIPTION
This should keep your existing functionality intact, unless ROTP needs to be a different version for different versions of activerecord.  Either way, this should be more correct.
