### PR TITLE
Check for ActionController before injecting code

### DIFF
--- a/lib/google-authenticator-rails/action_controller/rails_adapter.rb
+++ b/lib/google-authenticator-rails/action_controller/rails_adapter.rb
@@ -33,4 +33,6 @@ module GoogleAuthenticatorRails
   end
 end
 
-ActionController::Base.send(:include, GoogleAuthenticatorRails::ActionController::Integration)
+if defined?(ActionController::Base)
+  ActionController::Base.send(:include, GoogleAuthenticatorRails::ActionController::Integration)
+end


### PR DESCRIPTION
I'm using this gem in a library that depends on ActionPack but doesn't require it upfront. The Rails adapter assumes that ActionController is loaded already, so I was an seeing uninitialized constant error.

```
uninitialized constant ActionController
/Users/priddle/.rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/gems/google-authenticator-rails-0.0.10/lib/google-authenticator-rails/action_controller/rails_adapter.rb:36:in `<top (required)>'
/Users/priddle/.rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/gems/google-authenticator-rails-0.0.10/lib/google-authenticator-rails/action_controller.rb:1:in `<top (required)>'
/Users/priddle/.rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/gems/google-authenticator-rails-0.0.10/lib/google-authenticator-rails.rb:20:in `block in <top (required)>'
/Users/priddle/.rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/gems/google-authenticator-rails-0.0.10/lib/google-authenticator-rails.rb:19:in `each'
/Users/priddle/.rbenv/versions/2.0.0-p451/lib/ruby/gems/2.0.0/gems/google-authenticator-rails-0.0.10/lib/google-authenticator-rails.rb:19:in `<top (required)>'
```

~~This PR tweaks the Rails adapter to use `ActiveSupport.on_load :action_controller` instead. The block is only executed when ActionController is actually loaded.~~ Rails 2 does not have `ActiveSupport.on_load` :frowning:

This PR tweaks the Rails adapter to check for `ActionController::Base`. If it is defined, the Rails adapter code is injected into `ActionController::Base`.
