### PR TITLE
add a destroy method to kill the session on demand

### DIFF
--- a/lib/google-authenticator-rails/session/persistence.rb
+++ b/lib/google-authenticator-rails/session/persistence.rb
@@ -31,6 +31,10 @@ module GoogleAuthenticatorRails
         new(user)
       end
 
+      def destroy
+        controller.cookies.delete cookie_key
+      end
+
       private
       def finder
         @_finder ||= klass.public_methods.include?(:where) ? :rails_3_finder : :rails_2_finder

--- a/spec/session/persistance_spec.rb
+++ b/spec/session/persistance_spec.rb
@@ -30,6 +30,14 @@ describe GoogleAuthenticatorRails::Session::Base do
           it           { should be_a SaltUserMfaSession }
           its(:record) { should eq user }
         end
+
+        context 'after destroy' do
+          before { UserMfaSession.destroy }
+
+          subject { UserMfaSession.find }
+
+          it { should be_nil }
+        end
       end
     end
 


### PR DESCRIPTION
My first thought was the make destroy an instance method but cookie_key is a private class method and MfaSession feels sort of like a singleton so maybe it's okay on the class.