### PR TITLE
Add Mfa cookie customization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,8 +310,8 @@ You can configure the MfaSession cookie by creating an initializer:
 # The cookie normally expires in 24 hours, you can change this to 1 month
 GoogleAuthenticatorRails.time_until_expiration = 1.month
 
-# You can override the cookie's key, by default this is <class>_mfa_credentials
-GoogleAuthenticatorRails.cookie_key = 'mfa_credentials'
+# You can override the suffix of the cookie's key, by default this is mfa_credentials
+GoogleAuthenticatorRails.cookie_key_suffix = 'mfa_credentials'
 
 # Rails offers a few more cookie options, by default only :httponly is turned on, you can change it to HTTPS only:
 GoogleAuthenticatorRails.cookie_options = { :httponly => true, :secure => true, :domain => :all }

--- a/README.md
+++ b/README.md
@@ -300,15 +300,24 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-## Other configuration
+## Cookie options
 
-By default, the cookie related to the MfaSession expires in 24 hours, but this can be changed:
+You can configure the MfaSession cookie by creating an initializer:
 
 ```ruby
 # config/initializers/google_authenticator_rails.rb
 
+# The cookie normally expires in 24 hours, you can change this to 1 month
 GoogleAuthenticatorRails.time_until_expiration = 1.month
+
+# You can override the cookie's key, by default this is <class>_mfa_credentials
+GoogleAuthenticatorRails.cookie_key = 'mfa_credentials'
+
+# Rails offers a few more cookie options, by default only :httponly is turned on, you can change it to HTTPS only:
+GoogleAuthenticatorRails.cookie_options = { :httponly => true, :secure => true, :domain => :all }
 ```
+
+Additional cookie option symbols can be found in the [Ruby on Rails guide](http://api.rubyonrails.org/classes/ActionDispatch/Cookies.html).
 
 ## Destroying the Cookie
 

--- a/lib/google-authenticator-rails.rb
+++ b/lib/google-authenticator-rails.rb
@@ -1,4 +1,4 @@
-# Stuff the gem requireds
+# Stuff the gem requires
 #
 require 'active_support'
 require 'active_record'
@@ -20,14 +20,20 @@ GOOGLE_AUTHENTICATOR_RAILS_PATH = File.dirname(__FILE__) + "/google-authenticato
    require GOOGLE_AUTHENTICATOR_RAILS_PATH + library
  end
 
- # Sets up some basic accessors for use with the ROTP module
+# Sets up some basic accessors for use with the ROTP module
 #
 module GoogleAuthenticatorRails
-  # Drift is set to 6 because ROTP drift is not inclusive.  This allows a drift of 5 seconds.
+  # Drift is set to 6 because ROTP drift is not inclusive. This allows a drift of 5 seconds.
   DRIFT = 6
 
   # How long a Session::Persistence cookie should last.
   @@time_until_expiration = 24.hours
+
+  # Name of a Session::Persistence cookie
+  @@cookie_key = nil
+
+  # Additional configuration passed to a Session::Persistence cookie.
+  @@cookie_options = { :httponly => true }
 
   def self.generate_password(secret, iteration)
     ROTP::HOTP.new(secret).at(iteration)
@@ -51,5 +57,21 @@ module GoogleAuthenticatorRails
 
   def self.time_until_expiration=(time_until_expiration)
     @@time_until_expiration = time_until_expiration
+  end
+
+  def self.cookie_key
+    @@cookie_key
+  end
+
+  def self.cookie_key=(key)
+    @@cookie_key = key
+  end
+
+  def self.cookie_options
+    @@cookie_options
+  end
+
+  def self.cookie_options=(options)
+    @@cookie_options = options
   end
 end

--- a/lib/google-authenticator-rails.rb
+++ b/lib/google-authenticator-rails.rb
@@ -29,8 +29,8 @@ module GoogleAuthenticatorRails
   # How long a Session::Persistence cookie should last.
   @@time_until_expiration = 24.hours
 
-  # Name of a Session::Persistence cookie
-  @@cookie_key = nil
+  # Last part of a Session::Persistence cookie's key
+  @@cookie_key_suffix = nil
 
   # Additional configuration passed to a Session::Persistence cookie.
   @@cookie_options = { :httponly => true }
@@ -59,12 +59,12 @@ module GoogleAuthenticatorRails
     @@time_until_expiration = time_until_expiration
   end
 
-  def self.cookie_key
-    @@cookie_key
+  def self.cookie_key_suffix
+    @@cookie_key_suffix
   end
 
-  def self.cookie_key=(key)
-    @@cookie_key = key
+  def self.cookie_key_suffix=(suffix)
+    @@cookie_key_suffix = suffix
   end
 
   def self.cookie_options

--- a/lib/google-authenticator-rails/session/persistence.rb
+++ b/lib/google-authenticator-rails/session/persistence.rb
@@ -59,14 +59,15 @@ module GoogleAuthenticatorRails
 
       def create_cookie(token, user_id)
         value = [token, user_id].join('::')
-        {
+        options = GoogleAuthenticatorRails.cookie_options || {}
+        options.merge(
           :value    => value,
           :expires  => GoogleAuthenticatorRails.time_until_expiration.from_now
-        }
+        )
       end
 
       def cookie_key
-        "#{klass.to_s.downcase}_mfa_credentials"
+        GoogleAuthenticatorRails.cookie_key || "#{klass.to_s.downcase}_mfa_credentials"
       end
     end
 

--- a/lib/google-authenticator-rails/session/persistence.rb
+++ b/lib/google-authenticator-rails/session/persistence.rb
@@ -67,7 +67,8 @@ module GoogleAuthenticatorRails
       end
 
       def cookie_key
-        GoogleAuthenticatorRails.cookie_key || "#{klass.to_s.downcase}_mfa_credentials"
+        suffix = "#{GoogleAuthenticatorRails.cookie_key_suffix}" || 'mfa_credentials'
+        "#{klass.to_s.downcase}_#{suffix}"
       end
     end
 


### PR DESCRIPTION
Related to issue https://github.com/jaredonline/google-authenticator/issues/26

Here's what I did:
- Added a cookie_key property that will override the cookie's name/key
- Added a cookie_options property that will be passed to the Rails create_cookie method
- Updated the README.md with the new options

Few notes:
- I started off with creating `httponly` and `secure` properties in `lib/google-authenticator-rails.rb`, but when you set the `secure` symbol you should set a `domain` as well. Instead of copying all of those cookie options, I decided to create a cookie_options property. This is also a bit easier to maintain when the Rails team decides to add options later on
- The person using this gem could of course decide to set the `value` or `expires` symbol in the cookie_options hash. This will have no effect, because the `merge` statement will override these values.
- I don't think these changes require any changes to the test spec
- This is the first time I have modified a gem, I'm not really sure how to test my changes :). Perhaps I should point the Gemfile of my project to a local folder to do that?

Let me know what you think.