### PR TITLE
Fix default value handling of cookie_key

### DIFF
--- a/lib/google-authenticator-rails/session/persistence.rb
+++ b/lib/google-authenticator-rails/session/persistence.rb
@@ -67,7 +67,7 @@ module GoogleAuthenticatorRails
       end
 
       def cookie_key
-        suffix = "#{GoogleAuthenticatorRails.cookie_key_suffix}" || 'mfa_credentials'
+        suffix = GoogleAuthenticatorRails.cookie_key_suffix || 'mfa_credentials'
         "#{klass.to_s.downcase}_#{suffix}"
       end
     end


### PR DESCRIPTION
The default `nil` value wasn't properly handled.
The `||` of course doesn't work on an empty string.

Sorry I should have noticed this in the test.