### PR TITLE
Fix a bug when google_label is not a string.

### DIFF
--- a/google-authenticator.gemspec
+++ b/google-authenticator.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "activerecord"
   gem.add_dependency "google-qr"
   gem.add_dependency "actionpack"
+  gem.add_dependency "rqrcode"
 
   gem.add_development_dependency "rspec",     "~> 2.8.0"
   gem.add_development_dependency "appraisal", "~> 0.5.1"

--- a/lib/google-authenticator-rails.rb
+++ b/lib/google-authenticator-rails.rb
@@ -5,6 +5,7 @@ require 'active_record'
 require 'openssl'
 require 'rotp'
 require 'google-qr'
+require 'rqrcode'
 
 # Stuff the gem is
 #

--- a/lib/google-authenticator-rails/active_record/helpers.rb
+++ b/lib/google-authenticator-rails/active_record/helpers.rb
@@ -14,6 +14,14 @@ module GoogleAuthenticatorRails # :nodoc:
         GoogleQR.new(:data => ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label.to_s), :size => "200x200").to_s
       end
 
+      def qr_code_png(size=12)
+        RQRCode::QRCode.new(ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label.to_s), :size => size).as_png
+      end
+
+      def qr_code_svg(size=12)
+        RQRCode::QRCode.new(ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label.to_s), :size => size).as_svg
+      end
+
       def google_label
         method = self.class.google_label_method
         case method

--- a/lib/google-authenticator-rails/active_record/helpers.rb
+++ b/lib/google-authenticator-rails/active_record/helpers.rb
@@ -14,9 +14,9 @@ module GoogleAuthenticatorRails # :nodoc:
         GoogleQR.new(:data => ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label.to_s), :size => "#{w}x#{h}").to_s
       end
 
-      def qr_code_png(size=200)
-       qrcode = RQRCode::QRCode.new(ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label.to_s))
-       qrcode.as_png(resize_gte_to: false, resize_exactly_to: false, fill: 'white', color: 'black', size: size, border_modules: 4, module_px_size: 6, file: nil)
+      def qr_code_png(size=200,level=:h)
+       qrcode = RQRCode::QRCode.new(ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label.to_s), :level => level.to_sym)
+       qrcode.as_png(:size => size)
       end
 
       def google_label

--- a/lib/google-authenticator-rails/active_record/helpers.rb
+++ b/lib/google-authenticator-rails/active_record/helpers.rb
@@ -6,8 +6,9 @@ module GoogleAuthenticatorRails # :nodoc:
         save
       end
 
-      def google_authentic?(code)
-        GoogleAuthenticatorRails.valid?(code, google_secret_value, self.class.google_drift)
+      def google_authentic?(code,drift=nil)
+        drift = self.class.google_drift if drift.nil?
+        GoogleAuthenticatorRails.valid?(code, google_secret_value, drift)
       end
 
       def google_qr_uri(w=200,h=200)

--- a/lib/google-authenticator-rails/active_record/helpers.rb
+++ b/lib/google-authenticator-rails/active_record/helpers.rb
@@ -10,8 +10,8 @@ module GoogleAuthenticatorRails # :nodoc:
         GoogleAuthenticatorRails.valid?(code, google_secret_value, self.class.google_drift)
       end
 
-      def google_qr_uri
-        GoogleQR.new(:data => ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label.to_s), :size => "200x200").to_s
+      def google_qr_uri(w=200,h=200)
+        GoogleQR.new(:data => ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label.to_s), :size => "#{w}x#{h}").to_s
       end
 
       def qr_code_png(size=12)

--- a/lib/google-authenticator-rails/active_record/helpers.rb
+++ b/lib/google-authenticator-rails/active_record/helpers.rb
@@ -22,6 +22,10 @@ module GoogleAuthenticatorRails # :nodoc:
         RQRCode::QRCode.new(ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label.to_s), :size => size).as_svg
       end
 
+      def qr_code_html(size=12)
+        RQRCode::QRCode.new(ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label.to_s), :size => size).as_html
+      end
+
       def google_label
         method = self.class.google_label_method
         case method

--- a/lib/google-authenticator-rails/active_record/helpers.rb
+++ b/lib/google-authenticator-rails/active_record/helpers.rb
@@ -14,16 +14,9 @@ module GoogleAuthenticatorRails # :nodoc:
         GoogleQR.new(:data => ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label.to_s), :size => "#{w}x#{h}").to_s
       end
 
-      def qr_code_png(size=12)
-        RQRCode::QRCode.new(ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label.to_s), :size => size).as_png
-      end
-
-      def qr_code_svg(size=12)
-        RQRCode::QRCode.new(ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label.to_s), :size => size).as_svg
-      end
-
-      def qr_code_html(size=12)
-        RQRCode::QRCode.new(ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label.to_s), :size => size).as_html
+      def qr_code_png(size=200)
+       qrcode = RQRCode::QRCode.new(ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label.to_s))
+       qrcode.as_png(resize_gte_to: false, resize_exactly_to: false, fill: 'white', color: 'black', size: size, border_modules: 4, module_px_size: 6, file: nil)
       end
 
       def google_label

--- a/lib/google-authenticator-rails/active_record/helpers.rb
+++ b/lib/google-authenticator-rails/active_record/helpers.rb
@@ -11,7 +11,7 @@ module GoogleAuthenticatorRails # :nodoc:
       end
 
       def google_qr_uri
-        GoogleQR.new(:data => ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label), :size => "200x200").to_s
+        GoogleQR.new(:data => ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label.to_s), :size => "200x200").to_s
       end
 
       def google_label

--- a/lib/google-authenticator-rails/active_record/helpers.rb
+++ b/lib/google-authenticator-rails/active_record/helpers.rb
@@ -22,14 +22,6 @@ module GoogleAuthenticatorRails # :nodoc:
         RQRCode::QRCode.new(ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label.to_s), :size => size).as_svg
       end
 
-      def qr_code_png
-        RQRCode::QRCode.new(ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label.to_s), :size => 200).as_png
-      end
-
-      def qr_code_svg
-        RQRCode::QRCode.new(ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label.to_s), :size => 200).as_svg
-      end
-
       def google_label
         method = self.class.google_label_method
         case method


### PR DESCRIPTION
When column_name used in google_label isn't a string the "google_qr_uri" does't work.
The problem is:
NoMethodError: undefined method `gsub' for 2010741:Fixnum
