### PR TITLE
Prevent deprecation warning in Rails 5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+vendor

--- a/google-authenticator.gemspec
+++ b/google-authenticator.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-qr"
   gem.add_dependency "actionpack"
 
+  gem.add_development_dependency "rake",      "~> 11.0"
   gem.add_development_dependency "rspec",     "~> 2.8.0"
   gem.add_development_dependency "appraisal", "~> 0.5.1"
   gem.add_development_dependency "sqlite3"

--- a/lib/google-authenticator-rails/action_controller/rails_adapter.rb
+++ b/lib/google-authenticator-rails/action_controller/rails_adapter.rb
@@ -22,7 +22,8 @@ module GoogleAuthenticatorRails
       def self.included(klass)
         raise RailsAdapter::LoadedTooLateError.new if defined?(::ApplicationController)
 
-        klass.prepend_before_filter(:activate_google_authenticator_rails)
+        method = klass.respond_to?(:prepend_before_action) ? :prepend_before_action : :prepend_before_filter
+        klass.send(method, :activate_google_authenticator_rails)
       end
 
       private


### PR DESCRIPTION
In Rails 5.0, following warning is displayed on startup.

> DEPRECATION WARNING: prepend_before_filter is deprecated and will be removed in Rails 5.1. Use prepend_before_action instead. (called from included at .../gems/google-authenticator-rails-1.2.1/lib/google-authenticator-rails/action_controller/rails_adapter.rb:25)
