### PR TITLE
Prevent breaking other Google gems on load

### DIFF
--- a/google-authenticator.gemspec
+++ b/google-authenticator.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "google-authenticator-rails"
   gem.require_paths = ["lib"]
-  gem.version       = Google::Authenticator::Rails::VERSION
+  gem.version       = GoogleAuthenticatorRails::VERSION
 
   gem.add_dependency "rotp", "= 1.6.1"
   gem.add_dependency "rails"

--- a/lib/google-authenticator-rails/version.rb
+++ b/lib/google-authenticator-rails/version.rb
@@ -1,7 +1,3 @@
-module Google
-  module Authenticator
-    module Rails
-      VERSION = "1.4.1"
-    end
-  end
+module GoogleAuthenticatorRails
+  VERSION = "1.4.1"
 end


### PR DESCRIPTION
When defining `module Google` in the `version.rb` file, it breaks autoloading of Google's own API gem. This PR just re-scopes the `VERSION` constant so that it falls under the actual name of the gem.