### PR TITLE
Support for custom issuers with a Proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,14 @@ class User
 end
 ```
 
+You can also use a Proc to set a dynamic issuer for multi-tenant applications or any other custom needs:
+
+```ruby
+class User
+  acts_as_google_authenticated :issuer => Proc.new { |user| user.admin? ? "Example Admin" : "example.com" }
+end
+```
+
 This way your user will have the name of your site at the authenticator card besides the current token.
 
 Here's what the issuers look like in Google Authenticator for iPhone:

--- a/lib/google-authenticator-rails/active_record/helpers.rb
+++ b/lib/google-authenticator-rails/active_record/helpers.rb
@@ -72,7 +72,8 @@ module GoogleAuthenticatorRails # :nodoc:
       end
 
       def google_issuer
-        self.class.google_issuer
+        issuer = self.class.google_issuer
+        issuer.is_a?(Proc) ? issuer.call(self) : issuer
       end
       
       def google_secret_encryptor

--- a/spec/google_authenticator_spec.rb
+++ b/spec/google_authenticator_spec.rb
@@ -237,8 +237,13 @@ describe GoogleAuthenticatorRails do
         end
   
         context 'custom proc' do
-          let(:user) { UserFactory.create ProcUser }
+          let(:user) { UserFactory.create ProcLabelUser }
           it { should eq "https://chart.googleapis.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest_user%40futureadvisor-admin%3Fsecret%3D#{secret}&chs=200x200" }
+        end
+        
+        context 'custom issuer' do
+          let(:user) { UserFactory.create ProcIssuerUser }
+          it { should eq "https://chart.googleapis.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest%40example.com%3Fissuer%3DFA%2BAdmin%26secret%3D#{secret}&chs=200x200" }
         end
   
         context 'method defined by symbol' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -117,8 +117,15 @@ class DriftUser < BaseUser
   acts_as_google_authenticated :drift => 31
 end
 
-class ProcUser < BaseUser
+class ProcLabelUser < BaseUser
   acts_as_google_authenticated :method => Proc.new { |user| "#{user.user_name}@futureadvisor-admin" }
+end
+
+class ProcIssuerUser < BaseUser
+  acts_as_google_authenticated :issuer => Proc.new { |user| user.admin? ? "FA Admin" :  "FutureAdvisor" }
+  def admin?
+    true
+  end
 end
 
 class SymbolUser < BaseUser


### PR DESCRIPTION
This adds support for setting a custom issuer in the case you're using this for a multi-tenant application or just need to add dynamic issuers for whatever reason.

I considered using the same exact pattern as `google_label` to enable method calls for setting a custom issuer, but then I thought that might break applications that are using a symbol for the issuer name for some reason. As it stands, this should be backwards compatible with existing applications regardless of what they are passing in as an `:issuer`.