### PR TITLE
update rotp version 3.3.0

### DIFF
--- a/google-authenticator.gemspec
+++ b/google-authenticator.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = GoogleAuthenticatorRails::VERSION
 
-  gem.add_dependency "rotp", "= 1.6.1"
+  gem.add_dependency "rotp", "= 3.3.0"
   gem.add_dependency "rails"
   gem.add_dependency "activerecord"
   gem.add_dependency "google-qr"

--- a/spec/google_authenticator_spec.rb
+++ b/spec/google_authenticator_spec.rb
@@ -6,12 +6,12 @@ describe GoogleAuthenticatorRails do
 
     context 'counter = 1' do
       let(:counter) { 1 }
-      it { should == 868864 }
+      it { should == "868864" }
     end
 
     context 'counter = 2' do
       let(:counter) { 2 }
-      it { should == 304404 }
+      it { should == "304404" }
     end
   end
 
@@ -19,7 +19,7 @@ describe GoogleAuthenticatorRails do
     let(:secret)         { '5qlcip7azyjuwm36' }
     let(:original_time)  { Time.parse("2012-08-07 11:11:00 AM +0700") }
     let!(:time)          { original_time }
-    let(:code)           { 495502 }
+    let(:code)           { "495502" }
 
     before do
       Time.stub!(:now).and_return(time)
@@ -243,7 +243,7 @@ describe GoogleAuthenticatorRails do
         
         context 'custom issuer' do
           let(:user) { UserFactory.create ProcIssuerUser }
-          it { should eq "https://chart.googleapis.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest%40example.com%3Fissuer%3DFA%2BAdmin%26secret%3D#{secret}&chs=200x200" }
+          it { should eq "https://chart.googleapis.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2FFA%2520Admin%3Atest%40example.com%3Fsecret%3D#{secret}%26issuer%3DFA%2BAdmin&chs=200x200" }
         end
   
         context 'method defined by symbol' do


### PR DESCRIPTION
update version rotp higher than 2.0.0. because default padding setting is changed false into true.
issue : https://github.com/jaredonline/google-authenticator/issues/42

```
require 'rotp'
require 'time'
time = Time.parse('2018-11-31 15:39:46 UTC')
secret = 'JBSWY3DPEHPK3PXP'

totp = ROTP::TOTP.new(secret)
timecode = totp.send(:timecode, time)
puts "1.6.1 #{totp.generate_otp(timecode, false)}" # => 1.6.1 62906
puts "2.0.0 #{totp.generate_otp(timecode)}"        # => 2.0.0 062906
```

https://github.com/mdp/rotp/blame/c82113eee6c9e7d0a03df8cf65ea50a2653c3916/lib/rotp/totp.rb#L29