### PR TITLE
Fix typo on MfaSessionController

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ class UserMfaSession < GoogleAuthenticatorRails::Session::Base
 end
 
 # app/controllers/mfa_session_controller.rb
-def class MfaSessionController < ApplicationController
+class MfaSessionController < ApplicationController
   def create
     UserMfaSession.create(user)
   end


### PR DESCRIPTION
`def class` was written by mistake