### PR TITLE
Fix Rails 6 ActionController::Base deprecation warnings

### DIFF
--- a/lib/google-authenticator-rails/action_controller/rails_adapter.rb
+++ b/lib/google-authenticator-rails/action_controller/rails_adapter.rb
@@ -34,6 +34,6 @@ module GoogleAuthenticatorRails
   end
 end
 
-if defined?(ActionController::Base)
+ActiveSupport.on_load(:action_controller) do
   ActionController::Base.send(:include, GoogleAuthenticatorRails::ActionController::Integration)
 end


### PR DESCRIPTION
Rails 6 is causing deprecation warning when trying to include helpers into ActionController::Base. It seems Autoloading during initialization is going to be an error condition in future versions of Rails.
```
DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper and ActionText::TagHelper.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload ActionText::ContentHelper, for example,
the expected changes won't be reflected in that stale Module object.

These autoloaded constants have been unloaded.

Please, check the "Autoloading and Reloading Constants" guide for solutions.
 (called from <main> at /Users/jorge/timp/panel-backend/config/environment.rb:5)
Loading development environment (Rails 6.0.2.1)
```

More info:
https://github.com/rails/rails/issues/36363
https://github.com/rails/rails/issues/36546