### PR TITLE
Rails 5.2 Upgrade Compatibility

### DIFF
--- a/lib/google-authenticator-rails/active_record/helpers.rb
+++ b/lib/google-authenticator-rails/active_record/helpers.rb
@@ -85,12 +85,9 @@ module GoogleAuthenticatorRails # :nodoc:
       end
 
       def self.get_google_secret_encryptor
-        encryptor = ActiveSupport::MessageEncryptor.new(Rails.application.key_generator.generate_key('Google-secret encryption key', 32))
-        legacy_encryptor_args = [
-          Rails.application.key_generator.generate_key('Google-secret encryption key', 32),
-          { cipher: 'aes-256-cbc' }
-        ]
-        encryptor.rotate(*legacy_encryptor_args)
+        encryption_key = Rails.application.key_generator.generate_key('Google-secret encryption key', 32)
+        encryptor = ActiveSupport::MessageEncryptor.new(encryption_key)
+        encryptor.rotate(encryption_key, cipher: 'aes-256-cbc') # Legacy support for Rails 5.2
         encryptor
       end
     end

--- a/lib/google-authenticator-rails/active_record/helpers.rb
+++ b/lib/google-authenticator-rails/active_record/helpers.rb
@@ -1,9 +1,9 @@
 module GoogleAuthenticatorRails # :nodoc:
   mattr_accessor :secret_encryptor
-  
+
   module ActiveRecord  # :nodoc:
     module Helpers
-      
+
       # Returns and memoizes the plain text google secret for this instance, irrespective of the
       # name of the google secret storage column and whether secret encryption is enabled for this model.
       #
@@ -16,7 +16,7 @@ module GoogleAuthenticatorRails # :nodoc:
           @google_secret_value = secret_in_db.present? && self.class.google_secrets_encrypted ? google_secret_encryptor.decrypt_and_verify(secret_in_db) : secret_in_db
         end
       end
-      
+
       def set_google_secret
         change_google_secret_to!(GoogleAuthenticatorRails::generate_secret)
       end
@@ -54,7 +54,7 @@ module GoogleAuthenticatorRails # :nodoc:
       def google_token_value
         self.__send__(self.class.google_lookup_token)
       end
-      
+
       def encrypt_google_secret!
         change_google_secret_to!(google_secret_column_value)
       end
@@ -63,7 +63,7 @@ module GoogleAuthenticatorRails # :nodoc:
       def default_google_label_method
         self.__send__(self.class.google_label_column)
       end
-      
+
       def google_secret_column_value
         self.__send__(self.class.google_secret_column)
       end
@@ -79,13 +79,19 @@ module GoogleAuthenticatorRails # :nodoc:
         issuer = self.class.google_issuer
         issuer.is_a?(Proc) ? issuer.call(self) : issuer
       end
-      
+
       def google_secret_encryptor
         GoogleAuthenticatorRails.secret_encryptor ||= GoogleAuthenticatorRails::ActiveRecord::Helpers.get_google_secret_encryptor
       end
-      
+
       def self.get_google_secret_encryptor
-        ActiveSupport::MessageEncryptor.new(Rails.application.key_generator.generate_key('Google-secret encryption key', 32))
+        encryptor = ActiveSupport::MessageEncryptor.new(Rails.application.key_generator.generate_key('Google-secret encryption key', 32))
+        legacy_encryptor_args = [
+          Rails.application.key_generator.generate_key('Google-secret encryption key', 32),
+          { cipher: 'aes-256-cbc' }
+        ]
+        encryptor.rotate(*legacy_encryptor_args)
+        encryptor
       end
     end
   end


### PR DESCRIPTION
In Rails 5.2 the default cipher used by `ActiveSupport::MessageEncryptor` was changed from AES-256-CBC to AES-256-GCM, PR [here](https://github.com/rails/rails/pull/29263). By default, the `MessageEncryptor` initialized by this library would inherit this new configuration option by default from Rails. This can cause errors (specifically, `ActiveSupport::MessageEncryptor::InvalidMessage`) if a Rails app running version 5.1.x or earlier encrypts secrets with the old cipher and is then upgraded to 5.2.x. This PR adds backwards compatibility to that process by rotating in the old cipher to the `MessageEncryptor` configuration ([docs](5bd8144f-cd03-4313-86d0-a4ae505a3883)).