### PR TITLE
updated destroy to delete cookies with domain all

### DIFF
--- a/lib/google-authenticator-rails/session/persistence.rb
+++ b/lib/google-authenticator-rails/session/persistence.rb
@@ -32,7 +32,7 @@ module GoogleAuthenticatorRails
       end
 
       def destroy
-        controller.cookies.delete cookie_key
+        controller.cookies.delete(cookie_key, domain: :all)
       end
 
       private


### PR DESCRIPTION
### ISSUE
I was destroying the cookies using `UserMfaSession::destroy` while logging out 
But on login, the cookies for that user were still there. 
On debugging I found this was missing.