### PR TITLE
Fix `RailsAdapter::LoadedTooLateError` with Zeitwerk

### DIFF
--- a/lib/google-authenticator-rails/action_controller/rails_adapter.rb
+++ b/lib/google-authenticator-rails/action_controller/rails_adapter.rb
@@ -20,7 +20,9 @@ module GoogleAuthenticatorRails
 
     module Integration
       def self.included(klass)
-        raise RailsAdapter::LoadedTooLateError.new if defined?(::ApplicationController)
+        if klass.descendants.map(&:name).include?("ApplicationController")
+          raise RailsAdapter::LoadedTooLateError.new
+        end
 
         method = klass.respond_to?(:prepend_before_action) ? :prepend_before_action : :prepend_before_filter
         klass.send(method, :activate_google_authenticator_rails)

--- a/spec/action_controller/integration_spec.rb
+++ b/spec/action_controller/integration_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe GoogleAuthenticatorRails::ActionController::Integration do
   describe '::included' do
     context 'ApplicationController already defined' do
-      before  { class ApplicationController < MockController; end }
-      after   { Object.send(:remove_const, :ApplicationController) }
-      subject { lambda { MockController.send(:include, GoogleAuthenticatorRails::ActionController::Integration) } }
+      # Autoload ApplicationController.
+      before  { ApplicationController }
+      subject { lambda { MockControllerWithApplicationController.send(:include, GoogleAuthenticatorRails::ActionController::Integration) } }
 
       it { should raise_error(GoogleAuthenticatorRails::ActionController::RailsAdapter::LoadedTooLateError) }
     end

--- a/spec/support/application_controller.rb
+++ b/spec/support/application_controller.rb
@@ -1,0 +1,2 @@
+class ApplicationController < MockControllerWithApplicationController
+end


### PR DESCRIPTION
Fixes #75.

Zeitwerk uses Ruby's built-in `autoload`, and `defined?` for an autoload constant always returns `"constant"`. So `defined?(::ApplicationController)` always returns `"constant"` in some situations.

After this pull request, GoogleAuthenticatorRails gem will check if `ApplicationController` is loaded or not by Active Support's `descendants` instead of `defined?`. This new way doesn't depend on Ruby's `autoload`.