### PR TITLE
Handle authentic check when secret is nil

### DIFF
--- a/lib/google-authenticator-rails/active_record/helpers.rb
+++ b/lib/google-authenticator-rails/active_record/helpers.rb
@@ -28,6 +28,8 @@ module GoogleAuthenticatorRails # :nodoc:
       end
 
       def google_authentic?(code)
+        raise ArgumentError, "Can't authenticate before google secret is set!" unless google_secret_value.present?
+
         GoogleAuthenticatorRails.valid?(code, google_secret_value, self.class.google_drift)
       end
 

--- a/lib/google-authenticator-rails/active_record/helpers.rb
+++ b/lib/google-authenticator-rails/active_record/helpers.rb
@@ -30,7 +30,7 @@ module GoogleAuthenticatorRails # :nodoc:
       def google_authentic?(code)
         raise ArgumentError, "Can't authenticate before google secret is set!" unless google_secret_value.present?
 
-        GoogleAuthenticatorRails.valid?(code, google_secret_value, self.class.google_drift)
+        GoogleAuthenticatorRails.valid?(code.to_s, google_secret_value, self.class.google_drift)
       end
 
       def google_qr_uri(size = nil)

--- a/spec/google_authenticator_spec.rb
+++ b/spec/google_authenticator_spec.rb
@@ -91,10 +91,10 @@ describe GoogleAuthenticatorRails do
           @user.google_secret_value.should(be_nil) && @user.reload.google_secret_value.should(be_nil)
         end
 
-        it 'is not authentic' do
+        it 'raises exception when checking authenticity' do
           @user.clear_google_secret!
 
-          @user.google_authentic?(code).should be_falsey
+          expect { @user.google_authentic?(code) }.to raise_error(ArgumentError)
         end
       end
 

--- a/spec/google_authenticator_spec.rb
+++ b/spec/google_authenticator_spec.rb
@@ -90,6 +90,12 @@ describe GoogleAuthenticatorRails do
           @user.clear_google_secret!
           @user.google_secret_value.should(be_nil) && @user.reload.google_secret_value.should(be_nil)
         end
+
+        it 'is not authentic' do
+          @user.clear_google_secret!
+
+          @user.google_authentic?(code).should be_falsey
+        end
       end
 
       it_behaves_like 'handles nil secrets'

--- a/spec/google_authenticator_spec.rb
+++ b/spec/google_authenticator_spec.rb
@@ -80,6 +80,12 @@ describe GoogleAuthenticatorRails do
         end
       end
 
+      context 'integer code validation' do
+        subject { user.google_authentic?(code.to_i) }
+
+        it { should be true }
+      end
+
       it 'creates a secret' do
         user.set_google_secret
         user.google_secret.should == secret


### PR DESCRIPTION
### Issue

Calling `google_authentic?(code)` on an ActiveRecord model with a nil `google_secret` throws an error:

`NoMethodError: undefined method 'tr' for nil:NilClass`

### Solution

For now I've written a spec to illustrate the failure - added next to existing tests for secrets being nil.

@jaredonline let me know if you have a preference on how to handle this - it does look like the root cause of the exception is in the `rotp` gem but I think it's worth adding a check/solution here. Couple of options:

1. Add `return false unless secret.present?` to line 57 of `lib/google-authenticator-rails.rb`. If this is preferred, does this check need to be added anywhere else?
2. Add `return false unless google_secret_value.present?` to line 31 of `lib/google-authenticator-rails/active_record/helpers.rb`
3. Instead of returning `false`, raise an exception in one of these places - maybe `ArgumentError` or similar? Right now the error isn't helpful in diagnosing why the call to `google_authentic?` fails.

Let me know if you have a preference and I can add it in, cheers.