### PR TITLE
replaced google qr generation with image-charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ end
 @user = User.new
 @user.set_google_secret           # => true
 @user.google_secret_value         # => 16-character plain-text secret, whatever the name of the secret column
-@user.google_qr_uri               # => http://path.to.google/qr?with=params
+@user.google_qr_uri               # => http://path.to.chart/qr?with=params
 @user.google_authentic?(123456)   # => true
 @user.clear_google_secret!        # => true
 @user.google_secret_value         # => nil

--- a/lib/google-authenticator-rails/active_record/acts_as_google_authenticated.rb
+++ b/lib/google-authenticator-rails/active_record/acts_as_google_authenticated.rb
@@ -21,7 +21,7 @@ module GoogleAuthenticatorRails # :nodoc:
       #   @user = user.new
       #   @user.set_google_secret           # => true
       #   @user.google_secret_value         # => 16-character decrypted secret
-      #   @user.google_qr_uri               # => http://path.to.google/qr?with=params
+      #   @user.google_qr_uri               # => http://path.to.chart/qr?with=params
       #   @user.google_authentic?(123456)   # => true
       #
       # Google Labels

--- a/lib/google-authenticator-rails/active_record/helpers.rb
+++ b/lib/google-authenticator-rails/active_record/helpers.rb
@@ -35,7 +35,7 @@ module GoogleAuthenticatorRails # :nodoc:
 
       def google_qr_uri(size = nil)
         data = ROTP::TOTP.new(google_secret_value, :issuer => google_issuer).provisioning_uri(google_label)
-        "https://chart.googleapis.com/chart?cht=qr&chl=#{CGI.escape(data)}&chs=#{size || self.class.google_qr_size}"
+        "https://image-charts.com/chart?cht=qr&chl=#{CGI.escape(data)}&chs=#{size || self.class.google_qr_size}"
       end
 
       def google_qr_to_base64(size = 200)

--- a/spec/google_authenticator_spec.rb
+++ b/spec/google_authenticator_spec.rb
@@ -138,7 +138,7 @@ describe GoogleAuthenticatorRails do
         end
 
         it 'generates a url for a qr code' do
-          @user.google_qr_uri.should == "https://chart.googleapis.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest%2540example.com%3Fsecret%3D#{secret}&chs=200x200"
+          @user.google_qr_uri.should == "https://image-charts.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest%2540example.com%3Fsecret%3D#{secret}&chs=200x200"
         end
       end
 
@@ -245,48 +245,48 @@ describe GoogleAuthenticatorRails do
         before      { user.set_google_secret }
         subject     { user.google_qr_uri }
 
-        it { should eq "https://chart.googleapis.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest%2540example.com%3Fsecret%3D#{secret}&chs=200x200" }
+        it { should eq "https://image-charts.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest%2540example.com%3Fsecret%3D#{secret}&chs=200x200" }
 
         context 'custom column name' do
           let(:user) { UserFactory.create ColumnNameUser }
-          it { should eq "https://chart.googleapis.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest_user%3Fsecret%3D#{secret}&chs=200x200" }
+          it { should eq "https://image-charts.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest_user%3Fsecret%3D#{secret}&chs=200x200" }
         end
 
         context 'custom proc' do
           let(:user) { UserFactory.create ProcLabelUser }
-          it { should eq "https://chart.googleapis.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest_user%2540futureadvisor-admin%3Fsecret%3D#{secret}&chs=200x200" }
+          it { should eq "https://image-charts.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest_user%2540futureadvisor-admin%3Fsecret%3D#{secret}&chs=200x200" }
         end
 
         context 'custom issuer' do
           let(:user) { UserFactory.create ProcIssuerUser }
-          it { should eq "https://chart.googleapis.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2FFA%2520Admin%3Atest%2540example.com%3Fsecret%3D#{secret}%26issuer%3DFA%2520Admin&chs=200x200" }
+          it { should eq "https://image-charts.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2FFA%2520Admin%3Atest%2540example.com%3Fsecret%3D#{secret}%26issuer%3DFA%2520Admin&chs=200x200" }
         end
 
         context 'method defined by symbol' do
           let(:user) { UserFactory.create SymbolUser }
-          it { should eq "https://chart.googleapis.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest%2540example.com%3Fsecret%3D#{secret}&chs=200x200" }
+          it { should eq "https://image-charts.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest%2540example.com%3Fsecret%3D#{secret}&chs=200x200" }
         end
 
         context 'method defined by string' do
           let(:user) { UserFactory.create StringUser }
-          it { should eq "https://chart.googleapis.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest%2540example.com%3Fsecret%3D#{secret}&chs=200x200" }
+          it { should eq "https://image-charts.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest%2540example.com%3Fsecret%3D#{secret}&chs=200x200" }
         end
 
         context 'custom qr size' do
           let(:user) { UserFactory.create QrCodeUser }
-          it { should eq "https://chart.googleapis.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest%2540example.com%3Fsecret%3D#{secret}&chs=300x300" }
+          it { should eq "https://image-charts.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest%2540example.com%3Fsecret%3D#{secret}&chs=300x300" }
         end
 
         context 'qr size passed to method' do
           subject { user.google_qr_uri('400x400') }
           let(:user) { UserFactory.create StringUser }
-          it { should eq "https://chart.googleapis.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest%2540example.com%3Fsecret%3D#{secret}&chs=400x400" }
+          it { should eq "https://image-charts.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest%2540example.com%3Fsecret%3D#{secret}&chs=400x400" }
         end
 
         context 'qr size passed to method and size set on model' do
           let(:user) { UserFactory.create QrCodeUser }
           subject { user.google_qr_uri('400x400') }
-          it { should eq "https://chart.googleapis.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest%2540example.com%3Fsecret%3D#{secret}&chs=400x400" }
+          it { should eq "https://image-charts.com/chart?cht=qr&chl=otpauth%3A%2F%2Ftotp%2Ftest%2540example.com%3Fsecret%3D#{secret}&chs=400x400" }
         end
 
         context 'generates base64 image' do


### PR DESCRIPTION
I was having difficulty using the QR generator in my rails app. After some research it seems like the API used in this gem was shutdown a few years ago

https://groups.google.com/g/google-chart-api/c/ZPo9qj8-uRc